### PR TITLE
Add login protection to portal

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+</head>
+<body>
+    <h1>Please log in</h1>
+    {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
+    <form method="post">
+        <input type="password" name="password" placeholder="Password" required>
+        <button type="submit">Login</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add login page requiring SHA3-512 password
- restrict major endpoints with a `login_required` decorator

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684acad49130832098a12e332531293f