### PR TITLE
Add cucumber shop with Bitcoin checkout

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ gunicorn
 speechrecognition
 ffmpeg-python
 werkzeug
+requests

--- a/templates/checkout.html
+++ b/templates/checkout.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Checkout</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; text-align: center; }
+        code { font-size: 1.2em; }
+    </style>
+</head>
+<body>
+    <h1>Pay with Bitcoin</h1>
+    <p>Amount due: <strong>{{ euro_amount }} EUR</strong> (~<strong>{{ '{:.8f}'.format(btc_amount) }} BTC</strong>)</p>
+    <p>Please send the exact amount to the following address:</p>
+    <code>{{ address }}</code>
+    <p id="status">Waiting for payment...</p>
+
+    <script>
+    function check() {
+        fetch('{{ url_for('check_payment') }}')
+          .then(r => r.json())
+          .then(data => {
+            if (data.status === 'paid') {
+                document.getElementById('status').textContent = 'Payment received!';
+                clearInterval(interval);
+            }
+          });
+    }
+    const interval = setInterval(check, 15000);
+    </script>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,5 +7,6 @@
 <body>
     <h1>Welcome to Candyland Portal</h1>
     <p><a href="/functions1">Go to Functions 1</a></p>
+    <p><a href="{{ url_for('shop') }}">Buy Cucumbers</a></p>
 </body>
 </html>

--- a/templates/shop.html
+++ b/templates/shop.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Buy Cucumbers</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; text-align: center; }
+        .images { display: flex; justify-content: center; gap: 20px; }
+        .images img { max-width: 300px; height: auto; border-radius: 8px; }
+        form { margin-top: 20px; }
+    </style>
+</head>
+<body>
+    <h1>Cucumber Shop</h1>
+    <p>Fresh cucumbers for only €5 each. Pay with Bitcoin.</p>
+    <div class="images">
+        <img src="https://source.unsplash.com/featured/400x300/?cucumber" alt="Cucumber photo 1">
+        <img src="https://source.unsplash.com/featured/400x300/?vegetable" alt="Cucumber photo 2">
+    </div>
+    <form action="{{ url_for('checkout') }}" method="post">
+        <label for="qty">Quantity:</label>
+        <input type="number" id="qty" name="quantity" value="1" min="1">
+        <button type="submit">Buy with Bitcoin</button>
+    </form>
+    <p><a href="{{ url_for('home') }}">Back to Home</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add cucumber store pages with images
- integrate new shop and checkout routes
- poll blockchain to confirm bitcoin payment
- link the new shop from the home page
- add `requests` to requirements
- replace local cucumber photos with remote sources to avoid binary files

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684b19f305e08320a49112cbf3a18e09